### PR TITLE
Rename mbo_bzl to bzl

### DIFF
--- a/.bcr/metadata.template.json
+++ b/.bcr/metadata.template.json
@@ -1,5 +1,5 @@
 {
-  "homepage": "https://github.com/helly25/mbo_bzl",
+  "homepage": "https://github.com/helly25/bzl",
   "maintainers": [
     {
       "name": "helly25",
@@ -8,7 +8,7 @@
     }
   ],
   "repository": [
-    "github:helly25/mbo_bzl"
+    "github:helly25/bzl"
   ],
   "versions": [],
   "yanked_versions": {}

--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -11,4 +11,4 @@ tasks:
     platform: ${{ platform }}
     bazel: ${{ bazel }}
     build_targets:
-      - '@helly25_mbo//mbo_bzl:versions_tests'
+      - '@helly25_mbo//bzl/...'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,5 +10,5 @@ jobs:
     permissions:
       contents: write
     with:
-      release_files: mbo_bzl-*.tar.gz
+      release_files: bzl-*.tar.gz
       prerelease: true

--- a/.github/workflows/release_prep.sh
+++ b/.github/workflows/release_prep.sh
@@ -21,9 +21,9 @@
 set -euo pipefail
 
 # Custom args to update as needed.
-PACKAGE_NAME="mbo_bzl"
-BAZELMOD_NAME="helly25_mbo_bzl"
-WORKSPACE_NAME="helly25_mbo_bzl"
+PACKAGE_NAME="bzl"
+BAZELMOD_NAME="helly25_bzl"
+WORKSPACE_NAME="helly25_bzl"
 PATCHES=()
 
 # Automatic vars from workflow integration.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,12 +53,12 @@ repos:
   - id: buildifier-lint
     args: ["--warnings=all"]
 
-#- repo: https://github.com/lovesegfault/beautysh
-#  rev: v6.2.1
-#  hooks:
-#  - id: beautysh
-#
-#- repo: https://github.com/koalaman/shellcheck-precommit
-#  rev: v0.10.0
-#  hooks:
-#  - id: shellcheck
+- repo: https://github.com/lovesegfault/beautysh
+  rev: v6.2.1
+  hooks:
+  - id: beautysh
+
+- repo: https://github.com/koalaman/shellcheck-precommit
+  rev: v0.10.0
+  hooks:
+  - id: shellcheck

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -11,11 +11,4 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific languag
 
-"""Module helly25_bzl."""
-
-module(
-    name = "helly25_bzl",
-    version = "0.1.0",
-)
-
-bazel_dep(name = "bazel_skylib", version = "1.7.1")
+"""Empty root module for @helly25/mbo."""

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Helly25 bzl, a Bazel support library
 
-This library provide Bazel Skylark functionality meant to help in maintaining other libraries.
+This library provides [Bazel](http://bazel.build) [Starlark](https://bazel.build/rules/language) functionality meant to help in maintaining other libraries.
+
+[![Test](https://github.com/helly25/bzl/actions/workflows/main.yml/badge.svg)](https://github.com/helly25/bzl/actions/workflows/main.yml)
 
 ## Versions
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# Helly25 mbo_bzl, a Bazel support library
+# Helly25 bzl, a Bazel support library
 
 This library provide Bazel Skylark functionality meant to help in maintaining other libraries.
 
 ## Versions
 
-The `@mbo_bzl//mbo_bzl:versions.bzl` sub-libray provides:
+The `@helly25_bzl//bzl/versions:versions_bzl` sub-libray provides:
 
 * `versions` a single import structure:
 

--- a/RULES.md
+++ b/RULES.md
@@ -11,7 +11,7 @@ Some rules for the code layout and its development.
     read much more often then written.
   * Auto formatting also prevents pointless discussions like where '*' goes.
   * The guide mostly follows Google style: https://google.github.io/styleguide/
-* All exported library code is in the directory 'mbo_bzl'.
+* All exported library code is in the directory 'bzl'.
 * All public / exported code must:
   * be tested,
   * have a documentaion.

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-workspace(name = "helly25_mbo_bzl")
+workspace(name = "helly25_bzl")
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 

--- a/bzl/BUILD.bazel
+++ b/bzl/BUILD.bazel
@@ -11,11 +11,4 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific languag
 
-"""Module helly25_bzl."""
-
-module(
-    name = "helly25_bzl",
-    version = "0.1.0",
-)
-
-bazel_dep(name = "bazel_skylib", version = "1.7.1")
+"""Empty build file for @helly25_mbo//mbo."""

--- a/bzl/versions/BUILD.bazel
+++ b/bzl/versions/BUILD.bazel
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific languag
 
-"""Implements verison comparisons."""
+"""A starlark implementation of versioning functions that mostly follow semver."""
 
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load(":versions_test.bzl", "versions_test_suite")
@@ -21,6 +21,12 @@ package(default_visibility = ["//visibility:private"])
 bzl_library(
     name = "versions_bzl",
     srcs = ["versions.bzl"],
+    visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "versions",
+    actual = "versions_bzl",
     visibility = ["//visibility:public"],
 )
 

--- a/bzl/versions/versions.bzl
+++ b/bzl/versions/versions.bzl
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific languag
 
-"""A starlark implementation of versioning functions that follow mostly semver.
+"""A starlark implementation of versioning functions that mostly follow semver.
 
 Semantic Versioning (Semver) is defined at https://semver.org/
 

--- a/bzl/versions/versions_test.bzl
+++ b/bzl/versions/versions_test.bzl
@@ -14,7 +14,7 @@
 """Unit tests for versions.bzl."""
 
 load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
-load("//mbo_bzl:versions.bzl", "versions")
+load("//bzl/versions:versions.bzl", "versions")
 
 def _versions_parse_test(ctx):
     """Unit tests for `versions.parse`."""


### PR DESCRIPTION
The original name `mbo_bzl` is too long and somewhat misleading as it is not related to the mbo lib.

Hence the new name of just `bzl` which makes it `@helly25_bzl`. with top source directory `bzl`.