### PR TITLE
Feat/skip_build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.3.0
+
+* Added `skip_build` parameter to control whether comparisons adhere to Semver-10.
+* [BC] Changed `version.parse` and `version.compare` to take parameter `error` as a keyword only parameter.
+
 # 0.2.1
 
 * Improved support for mixed type comparisons.

--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ The version parameters support:
 - anything else is an error and the functions will `fail`.
 - unlike Semver, the function allows any number of numeric version components.
 
+Note: Most functions support a `skip_build` parameter. If `True`, then any
+present build component will be dropped. Conclusively the parameter is `True`
+by default for parsing and `False` for comparisons since Semver dictates that
+that the build component must be ignored for precedence (see
+[Semver-10](https://semver.org/#spec-item-10)).
+
 The functionality has exhaustive tests. If something still works wrong please,
 file a bug report or propose a fix.
 

--- a/tools/header.txt
+++ b/tools/header.txt
@@ -1,22 +1,14 @@
-# Copyright 2025 The Helly25 Authors.
+# SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+# SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#      http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-"""Module helly25_bzl."""
-
-module(
-    name = "helly25_bzl",
-    version = "0.3.0",
-)
-
-bazel_dep(name = "bazel_skylib", version = "1.7.1")


### PR DESCRIPTION
* Added `skip_build` parameter to control whether comparisons adhere to Semver-10.
* [BC] Changed `version.parse` and `version.compare` to take parameter `error` as a keyword only parameter.
* Updated release_prep.sh script (drop some dev files, empty root BUILD file, write version to VERSION file).
*