### PR TITLE
feat(paths): add ensure_trailing_slash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # 0.4.3
 
+- Added `paths.ensure_trailing_slash` and `paths.ensure_trailing_slash_windows` to append a single trailing separator, handling roots and existing trailing separators. An optional `default_if_empty` controls the fallback for empty input (e.g. `"/"` to anchor at the platform root).
+
 # 0.4.2
 
 - Fix release naming and tagging scheme back to "1.2.3" style without 'v' prefix.

--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ Provides:
   - `paths` is a single import structure:
     - `collapse`: Collapse '.' and '..' path segments for normalized Unix paths.
     - `collapse_windows`: Collapse '.' and '..' path segments for normalized Windows paths.
+    - `ensure_trailing_slash`: Ensure a Unix path ends with a single trailing slash.
+    - `ensure_trailing_slash_windows`: Ensure a Windows path ends with a single trailing backslash.
     - `is_absolute`: Returns `True` if a Unix path is absolute.
     - `is_absolute_windows`: Returns `True` if a Windows path is absolute.
     - `join`: Join path elements and return as normalized Unix paths.

--- a/bzl/paths/paths.bzl
+++ b/bzl/paths/paths.bzl
@@ -155,6 +155,49 @@ def _normalize(path, collapse = False, is_windows = False):
 
     return final_path
 
+def _ensure_trailing_slash(path, collapse = False, default_if_empty = "", is_windows = False):
+    """Ensures the path ends with exactly one trailing separator, after normalization.
+
+    The path is first normalized (redundant and trailing separators removed, slashes
+    standardized), then a single trailing separator is appended -- unless the path is empty or is
+    a root that already carries its own separator.
+
+    Edge cases:
+        * An empty input falls back to `default_if_empty` (default ""). With the default, the
+          result stays "" -- returning a bare separator would wrongly promote a relative path to an
+          absolute one. Pass `default_if_empty = "/"` to instead anchor empty input at the root.
+        * Roots keep their single separator and are never doubled (e.g. "/" -> "/", "C:" -> "C:\\",
+          and the UNC root "//" -> "\\\\").
+        * One or more existing trailing separators collapse to exactly one (e.g. "a//" -> "a/").
+
+    Args:
+        path: The input path string.
+        collapse: If True, applies '..' segment collapsing during normalization.
+        default_if_empty: Path to fall back to when `path` normalizes to empty. It is itself
+            normalized and given a trailing separator, so a single OS-agnostic "/" yields the
+            correct root per platform ("/" on Unix, "\\" on Windows) without hard-coding a
+            separator at the call site. The default "" preserves the empty result.
+        is_windows: If True, applies Windows-specific normalization and uses '\\' as the separator.
+    Returns:
+        The normalized path ending in a single separator, or "" when both `path` and
+        `default_if_empty` normalize to empty.
+    """
+    normalized = _normalize(path, collapse = collapse, is_windows = is_windows)
+    if not normalized:
+        # Fall back to the caller-provided default, processed identically so its OS-specific root
+        # form is derived rather than assumed (e.g. "/" -> "\\" on Windows).
+        normalized = _normalize(default_if_empty, collapse = collapse, is_windows = is_windows)
+    if not normalized:
+        return ""
+
+    separator = "\\" if is_windows else "/"
+
+    # Roots (e.g. "/", "C:\\", the UNC root "\\\\") already end in their separator; don't double it.
+    if normalized.endswith(separator):
+        return normalized
+
+    return normalized + separator
+
 def _join(*parts, collapse = False, is_windows = False):
     """Joins path parts by stitching them together with a separator, then normalizes.
 
@@ -209,6 +252,8 @@ def _forward_kwargs(kwargs, **overrides):
 paths = struct(
     collapse = _collapse,
     collapse_windows = lambda path: _collapse(path, is_windows = True),
+    ensure_trailing_slash = _ensure_trailing_slash,
+    ensure_trailing_slash_windows = lambda path, **kwargs: _ensure_trailing_slash(path, **_forward_kwargs(kwargs, is_windows = True)),
     is_absolute = _is_absolute,
     is_absolute_windows = lambda path: _is_absolute(path, is_windows = True),
     join = _join,

--- a/bzl/paths/paths_test.bzl
+++ b/bzl/paths/paths_test.bzl
@@ -44,6 +44,52 @@ def _collapse_windows_test(ctx):
 
     return unittest.end(env)
 
+def _ensure_trailing_slash_test(ctx):
+    """Unit tests for `paths.ensure_trailing_slash` on Unix."""
+    env = unittest.begin(ctx)
+
+    _assert_eq(env, 1, paths.ensure_trailing_slash(""), "", "Empty stays empty; never promoted to an absolute root")
+    _assert_eq(env, 2, paths.ensure_trailing_slash("/"), "/", "Root keeps its single slash")
+    _assert_eq(env, 3, paths.ensure_trailing_slash("//"), "/", "Multiple root slashes collapse to one")
+    _assert_eq(env, 4, paths.ensure_trailing_slash("///"), "/")
+    _assert_eq(env, 5, paths.ensure_trailing_slash("a"), "a/")
+    _assert_eq(env, 6, paths.ensure_trailing_slash("a/"), "a/", "Idempotent when already ending in a slash")
+    _assert_eq(env, 7, paths.ensure_trailing_slash("a//"), "a/", "Multiple trailing slashes collapse to one")
+    _assert_eq(env, 8, paths.ensure_trailing_slash("a/b/c"), "a/b/c/")
+    _assert_eq(env, 9, paths.ensure_trailing_slash("/a/b"), "/a/b/")
+    _assert_eq(env, 10, paths.ensure_trailing_slash("/a//b///"), "/a/b/", "Cleans interior and trailing slashes")
+    _assert_eq(env, 11, paths.ensure_trailing_slash("a/./b"), "a/b/", "Dot segments removed by normalization")
+    _assert_eq(env, 12, paths.ensure_trailing_slash("a/b/..", collapse = True), "a/", "Collapsing applies before the separator is added")
+    _assert_eq(env, 13, paths.ensure_trailing_slash("", default_if_empty = "/"), "/", "Empty falls back to the requested root")
+    _assert_eq(env, 14, paths.ensure_trailing_slash("", default_if_empty = "root"), "root/", "Non-root defaults also get a trailing slash")
+    _assert_eq(env, 15, paths.ensure_trailing_slash("//", default_if_empty = "x"), "/", "Default is ignored when the input is non-empty after normalization")
+    _assert_eq(env, 16, paths.ensure_trailing_slash("a", default_if_empty = "/"), "a/", "Default is ignored when a real path is present")
+    _assert_eq(env, 17, paths.ensure_trailing_slash("", default_if_empty = "."), "", "A default that normalizes away still yields empty")
+
+    return unittest.end(env)
+
+def _ensure_trailing_slash_windows_test(ctx):
+    """Unit tests for `paths.ensure_trailing_slash` on Windows."""
+    env = unittest.begin(ctx)
+
+    _assert_eq(env, 1, paths.ensure_trailing_slash_windows(""), "")
+    _assert_eq(env, 2, paths.ensure_trailing_slash_windows("/"), "\\", "Single leading slash is the local absolute root")
+    _assert_eq(env, 3, paths.ensure_trailing_slash_windows("//"), "\\\\", "UNC root keeps its two slashes, not three")
+    _assert_eq(env, 4, paths.ensure_trailing_slash_windows("C:"), "C:\\", "Drive letter gains its root separator")
+    _assert_eq(env, 5, paths.ensure_trailing_slash_windows("C:\\"), "C:\\", "Drive root is idempotent")
+    _assert_eq(env, 6, paths.ensure_trailing_slash_windows("C:/"), "C:\\")
+    _assert_eq(env, 7, paths.ensure_trailing_slash_windows("a"), "a\\")
+    _assert_eq(env, 8, paths.ensure_trailing_slash_windows("a\\b\\"), "a\\b\\", "Idempotent when already ending in a backslash")
+    _assert_eq(env, 9, paths.ensure_trailing_slash_windows("a/b//"), "a\\b\\", "Mixed and duplicate slashes collapse to one backslash")
+    _assert_eq(env, 10, paths.ensure_trailing_slash_windows("C:\\foo\\bar"), "C:\\foo\\bar\\")
+    _assert_eq(env, 11, paths.ensure_trailing_slash_windows("//server/share"), "\\\\server\\share\\", "UNC share gains a trailing separator")
+    _assert_eq(env, 12, paths.ensure_trailing_slash_windows("//server/share/"), "\\\\server\\share\\", "UNC share idempotent")
+    _assert_eq(env, 13, paths.ensure_trailing_slash_windows("", default_if_empty = "/"), "\\", "OS-agnostic '/' default resolves to the Windows local root")
+    _assert_eq(env, 14, paths.ensure_trailing_slash_windows("", default_if_empty = "C:"), "C:\\", "Drive-letter default resolves to the drive root")
+    _assert_eq(env, 15, paths.ensure_trailing_slash_windows(""), "", "Without a default, empty stays empty")
+
+    return unittest.end(env)
+
 def _is_absolute_test(ctx):
     """Unit tests for paths.is_absolute and paths.is_absolute_windows."""
     env = unittest.begin(ctx)
@@ -208,6 +254,8 @@ def _normalize_windows_test(ctx):
 
 collapse_test = unittest.make(_collapse_test)
 collapse_windows_test = unittest.make(_collapse_windows_test)
+ensure_trailing_slash_test = unittest.make(_ensure_trailing_slash_test)
+ensure_trailing_slash_windows_test = unittest.make(_ensure_trailing_slash_windows_test)
 is_absolute_test = unittest.make(_is_absolute_test)
 is_absolute_windows_test = unittest.make(_is_absolute_windows_test)
 join_test = unittest.make(_join_test)
@@ -223,6 +271,8 @@ def paths_test_suite():
         "paths_tests",
         collapse_test,
         collapse_windows_test,
+        ensure_trailing_slash_test,
+        ensure_trailing_slash_windows_test,
         is_absolute_test,
         is_absolute_windows_test,
         join_test,


### PR DESCRIPTION
## Summary

Adds `paths.ensure_trailing_slash` (+ `_windows` variant) to the paths library: normalize a path, then append exactly one trailing separator.

Edge cases are delegated to the existing `_normalize`, so they come for free:

| Input | Unix | Windows |
|---|---|---|
| `""` | `""` | `""` |
| `/` / `//` / `///` | `/` (root, never doubled) | `\` / `\\` (UNC, not tripled) |
| `C:` | — | `C:\` |
| `a//` | `a/` | `a\` |
| `a/` (already) | `a/` (idempotent) | — |
| `//server/share` | — | `\\server\share\` |

## Empty-input policy

`""` would naively become a bare separator, which wrongly promotes a relative path to an absolute root. So empty stays empty by default, with an opt-in `default_if_empty` for callers that *do* want to anchor at a root:

```python
paths.ensure_trailing_slash(p, default_if_empty = "/")          # "" -> "/"
paths.ensure_trailing_slash_windows(p, default_if_empty = "/")  # "" -> "\"   (normalized per-OS)
paths.ensure_trailing_slash_windows(p, default_if_empty = "C:") # "" -> "C:\"
```

The fallback is itself run through `_normalize`, so a single OS-agnostic `"/"` resolves to the correct platform root without hard-coding separators — and the policy lives in the call, not in an `if`/`or` at every call site.

## Changes

- `bzl/paths/paths.bzl` — new function + struct entries, following the existing `_forward_kwargs`/`collapse`/`is_windows` conventions.
- `bzl/paths/paths_test.bzl` — 17 Unix + 15 Windows assertions; suite registered.
- `README.md`, `CHANGELOG.md` (under pending `0.4.3`).

## Test plan

- [x] `bazel test //bzl/paths:all` — 12/12 pass.
- [x] `pre-commit` clean (buildifier, buildifier-lint, compare-versions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)