### PR TITLE
ci: auto-publish releases to the BCR via reusable workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,35 @@
+# Publish a new release to the Bazel Central Registry (BCR).
+#
+# Called by release.yml after a release is cut. Can also be run manually from
+# the Actions UI ("Run workflow") against a release tag to retry a failed run.
+name: Publish to BCR
+
+on:
+  workflow_call:
+    inputs:
+      tag_name:
+        required: true
+        type: string
+    secrets:
+      BCR_PUBLISH_TOKEN:
+        required: true
+  workflow_dispatch: {}
+
+jobs:
+  publish:
+    permissions:
+      contents: write
+    uses: bazel-contrib/publish-to-bcr/.github/workflows/publish.yaml@v1.4.1
+    with:
+      tag_name: ${{ inputs.tag_name || github.ref_name }}
+      registry_fork: helly25/bazel-central-registry
+      # Personal-account PAT: open a draft PR so the author can click "Ready for
+      # review" to approve it (GitHub forbids reviewing your own PR).
+      draft: true
+      # Integrity is computed from the tarball URL in .bcr/source.template.json.
+      # (The release also produces SLSA attestations; flip attest:true +
+      # download_default_release_artifacts:true to have the BCR verify them.)
+      attest: false
+      download_default_release_artifacts: false
+    secrets:
+      publish_token: ${{ secrets.BCR_PUBLISH_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,3 +14,17 @@ jobs:
     with:
       release_files: bzl-*.tar.gz
       prerelease: true
+
+  # Mirror the release to the Bazel Central Registry (replaces the retired
+  # publish-to-bcr GitHub App). See .github/workflows/publish.yaml.
+  publish:
+    needs: release
+    # Grant what publish.yaml's job requests; a called workflow cannot exceed
+    # the caller's permissions.
+    permissions:
+      contents: write
+    uses: ./.github/workflows/publish.yaml
+    with:
+      tag_name: ${{ github.ref_name }}
+    secrets:
+      BCR_PUBLISH_TOKEN: ${{ secrets.BCR_PUBLISH_TOKEN }}


### PR DESCRIPTION
Rolls out the BCR auto-publish workflow to bzl (after verifying it end-to-end on bashtest → draft BCR PR bazelbuild/bazel-central-registry#9275).

- **publish.yaml**: calls `bazel-contrib/publish-to-bcr/.github/workflows/publish.yaml@v1.4.1`, `registry_fork: helly25/bazel-central-registry`, draft PR, URL-based integrity.
- **release.yml**: `publish` job `needs: release`, grants `contents: write`.

Uses the *corrected* permission pattern (publish job grants `contents: write`; no top-level `read-all` in the wrapper) — the cascade that startup-failed bashtest twice. `BCR_PUBLISH_TOKEN` is already set on this repo.

After merge, the next tagged release (0.4.4) opens a draft BCR PR for `helly25_bzl`. bzl's release produces SLSA attestations; can flip `attest: true` later to have the BCR verify them.