### PR TITLE
ci(bcr): test on macos_arm64 instead of Intel macos

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -5,7 +5,7 @@ matrix:
     - 9.x
   platform:
     - ubuntu2404
-    - macos
+    - macos_arm64
     - windows
 tasks:
   verify_targets:


### PR DESCRIPTION
The BCR `macos` platform runs on Intel x86_64, which we no longer test. This switches the presubmit matrix to `macos_arm64` (Apple Silicon).

- platform: `macos` → `macos_arm64`