### PR TITLE
Rename module to mboworks_bzl

### DIFF
--- a/.bcr/metadata.template.json
+++ b/.bcr/metadata.template.json
@@ -1,5 +1,5 @@
 {
-  "homepage": "https://github.com/helly25/bzl",
+  "homepage": "https://github.com/mboworks/bzl",
   "maintainers": [
     {
       "name": "helly25",
@@ -8,7 +8,7 @@
     }
   ],
   "repository": [
-    "github:helly25/bzl"
+    "github:mboworks/bzl"
   ],
   "versions": [],
   "yanked_versions": {}

--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -13,4 +13,4 @@ tasks:
     platform: ${{ platform }}
     bazel: ${{ bazel }}
     build_targets:
-      - "@helly25_bzl//bzl/..."
+      - "@mboworks_bzl//bzl/..."

--- a/.github/workflows/release_prep.sh
+++ b/.github/workflows/release_prep.sh
@@ -27,7 +27,7 @@ function die() {
 
 # Custom args to update as needed.
 PACKAGE_NAME="bzl"
-BAZELMOD_NAME="helly25_bzl"
+BAZELMOD_NAME="mboworks_bzl"
 PATCHES=()
 
 # Automatic vars from workflow integration.
@@ -99,7 +99,7 @@ git archive --format=tar.gz --prefix="${PREFIX}/" -o "${ARCHIVE}" --add-virtual-
 
 # Print header
 echo "# Version ${VERSION}"
-echo "## [Changelog](https://github.com/helly25/${PACKAGE_NAME}/blob/${TAG}/CHANGELOG.md)"
+echo "## [Changelog](https://github.com/mboworks/${PACKAGE_NAME}/blob/${TAG}/CHANGELOG.md)"
 
 # Print Changelog
 awk '/^#/{f+=1;if(f>1)exit} !/^#/{print}' <CHANGELOG.md

--- a/.github/workflows/trigger_release.yaml
+++ b/.github/workflows/trigger_release.yaml
@@ -1,4 +1,4 @@
-# Reusable one-click release for helly25 Bazel-module repos.
+# Reusable one-click release for MBO Works Bazel-module repos.
 #
 # Call it from a repo's own .github/workflows/trigger_release.yml:
 #
@@ -7,7 +7,7 @@
 #       permissions:
 #         contents: read
 #         pull-requests: write   # so github-actions[bot] can approve the bump PR
-#       uses: helly25/bzl/.github/workflows/trigger_release.yaml@main
+#       uses: mboworks/bzl/.github/workflows/trigger_release.yaml@main
 #       secrets: inherit
 #
 # It operates on the CALLER repo's `main` and releases whatever version is in

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,7 +61,7 @@ repos:
     description: |
       * Use descriptive, referenceable TODOs. Examples:
         * `// TODO(nero.windstriker@helly25.com)`
-        * `# FIXME(https://github.com/helly25/bzl/issues/42)`
+        * `# FIXME(https://github.com/mboworks/bzl/issues/42)`
       * From the google style guide:
         Use FIXME/TODO comments for code that is temporary, a short-term solution.
         FIXME/TODOs should include the string `FIXME` or `TODO` in all caps, followed by a person's

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Empty root module for @helly25_bzl."""
+"""Empty root module for @mboworks_bzl."""

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # 0.5.1
 
+- Transfer the canonical repository from `helly25/bzl` to `mboworks/bzl` and
+  publish future releases under the new `mboworks_bzl` module name.
+
 # 0.5.0
 
 - [BC] Dropped legacy `WORKSPACE` support; the module is now bzlmod-only.

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Module helly25_bzl."""
+"""Module mboworks_bzl."""
 
 module(
-    name = "helly25_bzl",
+    name = "mboworks_bzl",
     version = "0.5.1",
 )
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Helly25 bzl, a Bazel support library
+# MBO Works bzl, a Bazel support library
 
 This library provides [Bazel](http://bazel.build) [Starlark](https://bazel.build/rules/language) functionality meant to help in maintaining other libraries.
 
-[![Test](https://github.com/helly25/bzl/actions/workflows/main.yml/badge.svg)](https://github.com/helly25/bzl/actions/workflows/main.yml)
+[![Test](https://github.com/mboworks/bzl/actions/workflows/main.yml/badge.svg)](https://github.com/mboworks/bzl/actions/workflows/main.yml)
 
 The following libraries are implemented:
 
@@ -57,7 +57,7 @@ if _versions.lt(my_version, min_version):
 
 Provides:
 
-- `load("@helly25_bzl//bzl/versions:versions_bzl", _versions = "versions")`
+- `load("@mboworks_bzl//bzl/versions:versions_bzl", _versions = "versions")`
   - `versions` is a single import structure:
     - `parse`: Parses a version.
     - `ge`: Implements `L >= R`.
@@ -80,7 +80,7 @@ NOTE: These functions do not support Windows drive letter relative paths.
 
 Provides:
 
-- `load("@helly25_bzl//bzl/paths:paths_bzl", _paths = "paths")`
+- `load("@mboworks_bzl//bzl/paths:paths_bzl", _paths = "paths")`
   - `paths` is a single import structure:
     - `collapse`: Collapse '.' and '..' path segments for normalized Unix paths.
     - `collapse_windows`: Collapse '.' and '..' path segments for normalized Windows paths.
@@ -103,10 +103,10 @@ However future version may drop Windows support.
 
 ### For MODULE.bazel
 
-See [helly25/bzl/releases](https://github.com/helly25/bzl/releases) to replace the version number.
+See [mboworks/bzl releases](https://github.com/mboworks/bzl/releases) to replace the version number.
 
 ```starlark
-bazel_dep(name = "helly25_bzl", version = "0.0.0")
+bazel_dep(name = "mboworks_bzl", version = "0.0.0")
 ```
 
 ### Dependencies

--- a/bzl/BUILD.bazel
+++ b/bzl/BUILD.bazel
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Empty build file for @helly25_bzl//bzl."""
+"""Empty build file for @mboworks_bzl//bzl."""

--- a/bzl/paths/paths.bzl
+++ b/bzl/paths/paths.bzl
@@ -14,7 +14,7 @@
 
 """A starlark implementation of path manipulationfunctions.
 
-SEE [README.md](https://github.com/helly25/bzl/blob/main/README.md).
+SEE [README.md](https://github.com/mboworks/bzl/blob/main/README.md).
 """
 
 def _collapse(path, is_windows = False):

--- a/bzl/versions/versions.bzl
+++ b/bzl/versions/versions.bzl
@@ -14,7 +14,7 @@
 
 """A starlark implementation of versioning functions that mostly follow semver.
 
-SEE [README.md](https://github.com/helly25/bzl/blob/main/README.md).
+SEE [README.md](https://github.com/mboworks/bzl/blob/main/README.md).
 """
 
 def _maybe_int(value):

--- a/tools/trigger_release.sh
+++ b/tools/trigger_release.sh
@@ -22,7 +22,7 @@ function die() {
     exit 1
 }
 
-REPO="helly25/bzl"
+REPO="mboworks/bzl"
 
 # Release approval is performed by a dedicated GitHub App (permissions:
 # "Pull requests: Read & write" and "Metadata: Read-only", installed on this


### PR DESCRIPTION
Rename the Bazel module and canonical project references after the repository transfer to mboworks/bzl.\n\nThis intentionally starts the new BCR module at 0.5.1; no historical helly25_bzl versions are changed or copied.\n\nValidation:\n- pre-commit run --all-files\n- bazel test //...