### PR TITLE
Strengthen release version and ownership checks

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# All repository changes are owned by the MBO Works maintainers. GitHub
+# requires approval from any one listed owner when code-owner review is enabled;
+# the pull request author cannot approve their own change.
+* @helly25 @Fab-Cat

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
       - uses: actions/setup-python@v5
         with:
           python-version: 3.11

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,11 +40,12 @@ repos:
   - id: compare-versions
     name: compare-versions
     description: |
-      Compare the versions in CHANGELOG.md and MODULES.bazel.
+      Require matching CHANGELOG.md and MODULE.bazel versions. After a release,
+      the first later commit must advance both beyond the latest release tag.
     language: system
     entry: .pre-commit/check_version.sh
     pass_filenames: False
-    types: [text]
+    always_run: true
   - id: no-do-not-merge
     name: No 'DO NOT MERGE'
     description: |

--- a/.pre-commit/check_version.sh
+++ b/.pre-commit/check_version.sh
@@ -15,11 +15,48 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+set -euo pipefail
+
 function die() { echo "ERROR: ${*}" 1>&2 ; exit 1; }
+
+function version_key() {
+    local version="${1}"
+    awk -F. '{ printf "%010d%010d%010d\n", $1, $2, $3 }' <<<"${version}"
+}
 
 BAZELMOD_VERSION="$(sed -rne 's,.*version = "([0-9]+([.][0-9]+)+.*)".*,\1,p' < MODULE.bazel|head -n1)"
 CHANGELOG_VERSION="$(sed -rne 's,^# ([0-9]+([.][0-9]+)+.*)$,\1,p' < CHANGELOG.md|head -n1)"
 
 if [ "${BAZELMOD_VERSION}" != "${CHANGELOG_VERSION}" ]; then
     die "MODULE.bazel (${BAZELMOD_VERSION}) != CHANGELOG.md (${CHANGELOG_VERSION})."
+fi
+
+if [[ ! "${BAZELMOD_VERSION}" =~ ^(0|[1-9][0-9]*)[.](0|[1-9][0-9]*)[.](0|[1-9][0-9]*)$ ]]; then
+    die "MODULE.bazel version (${BAZELMOD_VERSION}) must use numeric X.Y.Z format."
+fi
+
+# Only exact X.Y.Z tags are releases. Older v-prefixed tags and any other tag
+# namespaces are deliberately ignored.
+LATEST_RELEASE="$(
+    git tag --list |
+        awk '/^(0|[1-9][0-9]*)[.](0|[1-9][0-9]*)[.](0|[1-9][0-9]*)$/' |
+        while read -r version; do
+            printf '%s %s\n' "$(version_key "${version}")" "${version}"
+        done |
+        sort |
+        tail -n1 |
+        awk '{ print $2 }'
+)"
+
+if [[ -n "${LATEST_RELEASE}" ]] &&
+[[ "$(version_key "${BAZELMOD_VERSION}")" < "$(version_key "${LATEST_RELEASE}")" ]]; then
+    die "Development version (${BAZELMOD_VERSION}) is older than latest release tag (${LATEST_RELEASE})."
+fi
+
+# Equality is valid while main still points at the released commit. The first
+# subsequent commit (normally the next PR) must advance the development version.
+if [[ -n "${LATEST_RELEASE}" ]] &&
+[[ "${BAZELMOD_VERSION}" == "${LATEST_RELEASE}" ]] &&
+[[ "$(git rev-parse HEAD)" != "$(git rev-list -n1 "${LATEST_RELEASE}")" ]]; then
+    die "Development version (${BAZELMOD_VERSION}) still matches latest release tag (${LATEST_RELEASE}), but HEAD contains later work. Bump MODULE.bazel and CHANGELOG.md."
 fi


### PR DESCRIPTION
Extend the version hook so MODULE.bazel and CHANGELOG.md must match and use numeric X.Y.Z versions. Equality with the latest release is allowed while HEAD is the tagged release commit; the first later commit must advance both files. CI now fetches complete tag history, and the hook runs unconditionally.\n\nAdd repository-wide CODEOWNERS for @helly25 and @Fab-Cat. The repository ruleset can require a real code-owner review after this file merges.\n\nValidation:\n- release-tag commit equality passes\n- a later commit with the released version fails\n- advancing both files passes\n- pre-commit run --all-files