### PR TITLE
Migrate copyright and BCR ownership to MBO Works

### DIFF
--- a/.bcr/metadata.template.json
+++ b/.bcr/metadata.template.json
@@ -2,7 +2,7 @@
   "homepage": "https://github.com/mboworks/bzl",
   "maintainers": [
     {
-      "name": "helly25",
+      "name": "M. Boerger",
       "email": "marcus.boerger@gmail.com",
       "github": "helly25"
     }

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -22,7 +22,7 @@ jobs:
     uses: bazel-contrib/publish-to-bcr/.github/workflows/publish.yaml@v1.4.1
     with:
       tag_name: ${{ inputs.tag_name || github.ref_name }}
-      registry_fork: helly25/bazel-central-registry
+      registry_fork: mboworks/bazel-central-registry
       # Personal-account PAT: open a draft PR so the author can click "Ready for
       # review" to approve it (GitHub forbids reviewing your own PR).
       draft: true

--- a/.github/workflows/release_prep.sh
+++ b/.github/workflows/release_prep.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
+# SPDX-FileCopyrightText: Copyright (c) M. Boerger and the MBO Works authors
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/.pre-commit/check_version.sh
+++ b/.pre-commit/check_version.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
+# SPDX-FileCopyrightText: Copyright (c) M. Boerger and the MBO Works authors
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,4 +1,4 @@
-# Copyright 2025 The Helly25 Authors.
+# Copyright 2025 M. Boerger and the MBO Works authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,4 +1,4 @@
-# Copyright 2025 The Helly25 Authors.
+# Copyright 2025 M. Boerger and the MBO Works authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/bzl/BUILD.bazel
+++ b/bzl/BUILD.bazel
@@ -1,4 +1,4 @@
-# Copyright 2025 The Helly25 Authors.
+# Copyright 2025 M. Boerger and the MBO Works authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/bzl/paths/BUILD.bazel
+++ b/bzl/paths/BUILD.bazel
@@ -1,4 +1,4 @@
-# Copyright 2025 The Helly25 Authors.
+# Copyright 2025 M. Boerger and the MBO Works authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/bzl/paths/paths.bzl
+++ b/bzl/paths/paths.bzl
@@ -1,4 +1,4 @@
-# Copyright 2025 The Helly25 Authors.
+# Copyright 2025 M. Boerger and the MBO Works authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/bzl/paths/paths_test.bzl
+++ b/bzl/paths/paths_test.bzl
@@ -1,4 +1,4 @@
-# Copyright 2025 The Helly25 Authors.
+# Copyright 2025 M. Boerger and the MBO Works authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/bzl/versions/BUILD.bazel
+++ b/bzl/versions/BUILD.bazel
@@ -1,4 +1,4 @@
-# Copyright 2025 The Helly25 Authors.
+# Copyright 2025 M. Boerger and the MBO Works authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/bzl/versions/versions.bzl
+++ b/bzl/versions/versions.bzl
@@ -1,4 +1,4 @@
-# Copyright 2025 The Helly25 Authors.
+# Copyright 2025 M. Boerger and the MBO Works authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/bzl/versions/versions_test.bzl
+++ b/bzl/versions/versions_test.bzl
@@ -1,4 +1,4 @@
-# Copyright 2025 The Helly25 Authors.
+# Copyright 2025 M. Boerger and the MBO Works authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tools/header.txt
+++ b/tools/header.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
+# SPDX-FileCopyrightText: Copyright (c) M. Boerger and the MBO Works authors
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/trigger_release.sh
+++ b/tools/trigger_release.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
+# SPDX-FileCopyrightText: Copyright (c) M. Boerger and the MBO Works authors
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
## Summary

- attribute source files to M. Boerger and the MBO Works authors
- publish BCR changes through the transferred `mboworks/bazel-central-registry` fork
- use M. Boerger as the informational BCR maintainer name while retaining the `helly25` approval identity

## Validation

- `git diff --check`
- `pre-commit run --all-files`
- `bazel test //...`