### PR TITLE
Restore prerelease gate for BCR publication

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,9 @@ jobs:
       contents: write       # Required to create the release and upload bzl-*.tar.gz
     with:
       release_files: bzl-*.tar.gz
-      prerelease: false
+      # Keep the GitHub release provisional until the secondary BCR
+      # publication process has completed.
+      prerelease: true
 
   # Mirror the release to the Bazel Central Registry (replaces the retired
   # publish-to-bcr GitHub App). See .github/workflows/publish.yaml.


### PR DESCRIPTION
GitHub releases must remain prereleases while the secondary Bazel Central Registry publication process runs. Restore `prerelease: true` and document the lifecycle directly in the workflow.\n\nThis corrects the release-policy change merged in #47.