### PR TITLE
chore: normalize copyright attribution

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,4 +1,4 @@
-# Copyright 2025 M. Boerger and the MBO Works authors.
+# Copyright 2025 M. Boerger, the MBO Works authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,4 +1,4 @@
-# Copyright 2025 M. Boerger and the MBO Works authors.
+# Copyright 2025 M. Boerger, the MBO Works authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/bzl/BUILD.bazel
+++ b/bzl/BUILD.bazel
@@ -1,4 +1,4 @@
-# Copyright 2025 M. Boerger and the MBO Works authors.
+# Copyright 2025 M. Boerger, the MBO Works authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/bzl/paths/BUILD.bazel
+++ b/bzl/paths/BUILD.bazel
@@ -1,4 +1,4 @@
-# Copyright 2025 M. Boerger and the MBO Works authors.
+# Copyright 2025 M. Boerger, the MBO Works authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/bzl/paths/paths.bzl
+++ b/bzl/paths/paths.bzl
@@ -1,4 +1,4 @@
-# Copyright 2025 M. Boerger and the MBO Works authors.
+# Copyright 2025 M. Boerger, the MBO Works authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/bzl/paths/paths_test.bzl
+++ b/bzl/paths/paths_test.bzl
@@ -1,4 +1,4 @@
-# Copyright 2025 M. Boerger and the MBO Works authors.
+# Copyright 2025 M. Boerger, the MBO Works authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/bzl/versions/BUILD.bazel
+++ b/bzl/versions/BUILD.bazel
@@ -1,4 +1,4 @@
-# Copyright 2025 M. Boerger and the MBO Works authors.
+# Copyright 2025 M. Boerger, the MBO Works authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/bzl/versions/versions.bzl
+++ b/bzl/versions/versions.bzl
@@ -1,4 +1,4 @@
-# Copyright 2025 M. Boerger and the MBO Works authors.
+# Copyright 2025 M. Boerger, the MBO Works authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/bzl/versions/versions_test.bzl
+++ b/bzl/versions/versions_test.bzl
@@ -1,4 +1,4 @@
-# Copyright 2025 M. Boerger and the MBO Works authors.
+# Copyright 2025 M. Boerger, the MBO Works authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tools/header.txt
+++ b/tools/header.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) M. Boerger and the MBO Works authors
+# SPDX-FileCopyrightText: Copyright (c) M. Boerger, the MBO Works authors
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/trigger_release.sh
+++ b/tools/trigger_release.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# SPDX-FileCopyrightText: Copyright (c) M. Boerger and the MBO Works authors
+# SPDX-FileCopyrightText: Copyright (c) M. Boerger, the MBO Works authors
 # SPDX-License-Identifier: Apache-2.0
 
 set -euo pipefail


### PR DESCRIPTION
Use the canonical copyright wording selected for the transferred MBO Works projects.

This changes `M. Boerger and the MBO Works authors` to `M. Boerger, the MBO Works authors` in current source headers and the header template.

Validation:
- `pre-commit run --all-files`
- `git diff --check`