### PR TITLE
chore: configure Dependabot version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,7 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Dependabot currently monitors Bazel dependencies but not the actions used by CI. This adds weekly GitHub Actions version updates at the repository root.

Validation:
- `pre-commit run --files .github/dependabot.yml`
- Code builds and tests were not run because this changes only Dependabot configuration.