### PR TITLE
Finish copyright normalization

### DIFF
--- a/.github/workflows/release_prep.sh
+++ b/.github/workflows/release_prep.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# SPDX-FileCopyrightText: Copyright (c) M. Boerger and the MBO Works authors
+# SPDX-FileCopyrightText: Copyright (c) M. Boerger, the MBO Works authors
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/.pre-commit/check_version.sh
+++ b/.pre-commit/check_version.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# SPDX-FileCopyrightText: Copyright (c) M. Boerger and the MBO Works authors
+# SPDX-FileCopyrightText: Copyright (c) M. Boerger, the MBO Works authors
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
Finish the repository-wide copyright spelling selected for the MBO Works transfer.

Two release/version helper scripts were added after the earlier normalization
and retained the old `M. Boerger and the MBO Works authors` form. Change those
headers to the canonical `M. Boerger, the MBO Works authors` form.

Validation:

- `pre-commit run --files .github/workflows/release_prep.sh .pre-commit/check_version.sh`
- repository search confirms no old-form SPDX headers remain
- `git diff --check`
