### PR TITLE
Correct the LICENSE copyright notice

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright M. Boerger, the MBO Works authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
Replace the unfilled Apache License copyright placeholder with the MBO Works authorship notice while preserving the license's existing indentation.\n\nValidation: confirmed the diff changes only the copyright line; no runtime behavior is affected.