### PR TITLE
Integrate GitHub Actions dependency updates

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v7
-    - uses: bazel-contrib/setup-bazel@0.14.0
+    - uses: bazel-contrib/setup-bazel@0.19.0
       with:
         bazelisk-cache: true
         # Store build cache per workflow.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v7
         with:
           python-version: 3.11
       - uses: pre-commit/action@v3.0.1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
         with:
           python-version: 3.11
       - uses: pre-commit/action@v3.0.1
-      - uses: pre-commit-ci/lite-action@v1.0.2
+      - uses: pre-commit-ci/lite-action@v1.1.0
         if: always()
 
   test:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,7 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -24,7 +24,7 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
     - uses: bazel-contrib/setup-bazel@0.14.0
       with:
         bazelisk-cache: true
@@ -47,7 +47,7 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Ensure every job is wired into this gate
         env:
           NEEDS_JSON: ${{ toJSON(needs) }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -19,7 +19,7 @@ jobs:
   publish:
     permissions:
       contents: write
-    uses: bazel-contrib/publish-to-bcr/.github/workflows/publish.yaml@v1.4.1
+    uses: bazel-contrib/publish-to-bcr/.github/workflows/publish.yaml@v1.5.0
     with:
       tag_name: ${{ inputs.tag_name || github.ref_name }}
       registry_fork: mboworks/bazel-central-registry


### PR DESCRIPTION
Combine the five current GitHub Actions dependency updates into one reviewed
change while preserving their individual Dependabot pull requests.

## Included pull requests

- #51: `actions/checkout` 4 → 7
- #52: `pre-commit-ci/lite-action` 1.0.2 → 1.1.0
- #53: `bazel-contrib/setup-bazel` 0.14.0 → 0.19.0
- #54: `bazel-contrib/publish-to-bcr` 1.4.1 → 1.5.0
- #55: `actions/setup-python` 5 → 7

Each source branch was rebased sequentially onto this integration branch and
retains a separate signed+DCO commit. The five original PRs remain open.

## Validation

- `git diff --check origin/main...HEAD`
- `pre-commit run --all-files`
