### PR TITLE
Fix documentation examples and contributor instructions

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -59,8 +59,8 @@ representative at an online or offline event.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported to the community leaders responsible for enforcement at
-.
+reported to the maintainer, M. Boerger, at
+[marcus.boerger@gmail.com](mailto:marcus.boerger@gmail.com).
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,13 +4,14 @@ All contributions are generally welcome as long as they fit in with the concepts
 
 # Code Rules
 
-All code must adhere to the [RULES.dm](RULES.md) and mostly follows the [Google style](https://google.github.io/styleguide/). Where it diverges, pre-commit rules are in effect as much as possible.
+All code must adhere to the [RULES.md](RULES.md) and mostly follows the [Google style](https://google.github.io/styleguide/). Where it diverges, pre-commit rules are in effect as much as possible.
 
 # Run pre-commit
 
-All changes will be verified by the pre-commit rules. In order to check these before committing changes install the tool:
+All changes will be verified by the pre-commit rules. To check these before committing changes, install pre-commit and its Git hook:
 
 ```
+python3 -m pip install pre-commit
 pre-commit install
 ```
 
@@ -20,4 +21,4 @@ Once installed the verification can be triggered for all files as follows:
 pre-commit run -a
 ```
 
-Without the `-a` only the modified and staged files will be checked.
+Without `-a`, pre-commit checks the staged files.

--- a/README.md
+++ b/README.md
@@ -17,11 +17,12 @@ Comparators correctly respect major, minor and patch components, as well as
 Semver compliant 'pre-release' and 'build' components. The pre-release and build
 components are split at ".". Comparing pre-release parts works for alphabetical
 prefixes and numeric suffixes, so 'alpha', 'beta' and 'rc' as well as numbered
-version of those (e.g. 'alpha1' or rc-1') are supported. For pre-releases and
-build pieces a single '-' in front of the numeric parts is dropped (e.g. 'rc-1'
-becomes 'rc' + '1' while 'alpha--2' becomes 'alpha-' + '2').
+versions of those (e.g. 'alpha1' or 'rc-1') are supported. For pre-release
+pieces a single '-' in front of the numeric parts is dropped (e.g. 'rc-1'
+becomes 'rc' + '1' while 'alpha--2' becomes 'alpha-' + '2'). Build components
+are split only at dots; their prefixes and numeric suffixes are not separated.
 
-The full functionality is exposed as a singele struct containing all functions.
+The full functionality is exposed as a single struct containing all functions.
 
 The version parameters support:
 
@@ -35,9 +36,9 @@ The version parameters support:
 - unlike Semver, the function allows any number of numeric version components.
 
 Note: Most functions support a `skip_build` parameter. If `True`, then any
-present build component will be dropped. Conclusively the parameter is `True`
-by default for parsing and `False` for comparisons since Semver dictates that
-that the build component must be ignored for precedence (see
+present build component will be dropped. The parameter defaults to `False`
+for parsing and `True` for comparisons since Semver dictates that
+the build component must be ignored for precedence (see
 [Semver-10](https://semver.org/#spec-item-10)).
 
 The functionality has exhaustive tests. If something still works wrong please,
@@ -46,6 +47,8 @@ file a bug report or propose a fix.
 Example:
 
 ```starlark
+load("@mboworks_bzl//bzl/versions:versions.bzl", _versions = "versions")
+
 my_version = "25.33.42"
 min_version = (10, 11, 12)
 if _versions.lt(my_version, min_version):
@@ -57,7 +60,7 @@ if _versions.lt(my_version, min_version):
 
 Provides:
 
-- `load("@mboworks_bzl//bzl/versions:versions_bzl", _versions = "versions")`
+- `load("@mboworks_bzl//bzl/versions:versions.bzl", _versions = "versions")`
   - `versions` is a single import structure:
     - `parse`: Parses a version.
     - `ge`: Implements `L >= R`.
@@ -66,7 +69,7 @@ Provides:
     - `lt`: Implements `L < R`.
     - `eq`: Implements `L == R`.
     - `ne`: Implements `L != R`.
-    - `cmp`: Implements `L <=> R` aka `(L < R) - (L > R)`.
+    - `cmp`: Returns -1 if `L < R`, 0 if `L == R`, and 1 if `L > R`.
     - `compare`: Implements `L OP R`.
     - `check_one_requirement`: Checks a version adheres to a single requirement.
     - `check_all_requirements`: Checks a version adheres to a requirements list.
@@ -80,7 +83,7 @@ NOTE: These functions do not support Windows drive letter relative paths.
 
 Provides:
 
-- `load("@mboworks_bzl//bzl/paths:paths_bzl", _paths = "paths")`
+- `load("@mboworks_bzl//bzl/paths:paths.bzl", _paths = "paths")`
   - `paths` is a single import structure:
     - `collapse`: Collapse '.' and '..' path segments for normalized Unix paths.
     - `collapse_windows`: Collapse '.' and '..' path segments for normalized Windows paths.
@@ -97,9 +100,9 @@ Provides:
 
 ## Installation
 
-The library is available as a Bazel module (bzlmod) and works on MacOS, Ubuntu
-and Windows with Bazel version 7.x and 8.x (Other systems are simply not tested).
-However future version may drop Windows support.
+The library is available as a Bazel module (bzlmod) and supports macOS, Ubuntu
+and Windows with Bazel versions 7.x, 8.x and 9.x (other systems are not tested).
+However, future versions may drop Windows support.
 
 ### For MODULE.bazel
 

--- a/RULES.md
+++ b/RULES.md
@@ -1,6 +1,6 @@
 Some rules for the code layout and its development.
 
-* Everything is under Apache 2 license, see fle `LICENSE`.
+* Everything is under the Apache 2.0 license, see [LICENSE](LICENSE).
 * All sources must be unix-text files: https://en.wikipedia.org/wiki/Text_file
   * Lines end in {LF}.
   * The files are either empty or end in {LF}.
@@ -8,12 +8,12 @@ Some rules for the code layout and its development.
   * This provides consistent formatting.
   * The choices are meant to enable fast structural reading by humans.
   * It cares less about writing because there is auto formatting and code is
-    read much more often then written.
+    read much more often than written.
   * Auto formatting also prevents pointless discussions like where '*' goes.
   * The guide mostly follows Google style: https://google.github.io/styleguide/
 * All exported library code is in the directory 'bzl'.
 * All public / exported code must:
   * be tested,
-  * have a documentaion.
+  * have documentation.
 * API changes that are not backwards compatible should not occur in minor version changes.
 * Undocumented and private/internal APIs may be changed in any way at any time.


### PR DESCRIPTION
The documentation contains invalid Starlark load labels, reversed version comparison defaults and results, and incomplete contributor instructions. Correct the examples and descriptions to match the implementation, include Bazel 9 in the compatibility list, and fix the RULES.md link text and other typos.

Clarify pre-commit installation and staged-file checks, and fill the missing code-of-conduct reporting contact using the existing maintainer email in `.bcr/metadata.template.json`.

Validation: `pre-commit run -a` passed; `bazel test //...` passed all 23 tests; all five local Markdown links/anchors and the README load paths resolve; `git diff --check` passed.
